### PR TITLE
Player event on player communication

### DIFF
--- a/Projects/MakeMeLaugh_Server/Assets/Scripts/PlayerMessageEventArgs.cs
+++ b/Projects/MakeMeLaugh_Server/Assets/Scripts/PlayerMessageEventArgs.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+
+// Custom EventArgs class with additional information
+public class PlayerMessageEventArgs : EventArgs
+{
+    public PlayerMessage EventPlayerMessage { get; }
+
+    public PlayerMessageEventArgs(PlayerMessage playerMessage)
+    {
+        EventPlayerMessage = playerMessage;
+    }
+}

--- a/Projects/MakeMeLaugh_Server/Assets/Scripts/PlayerMessageEventArgs.cs.meta
+++ b/Projects/MakeMeLaugh_Server/Assets/Scripts/PlayerMessageEventArgs.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 45a73a683e884adfbe140c54dd81c3a1
+timeCreated: 1706384564

--- a/Projects/MakeMeLaugh_Server/Assets/Scripts/TransportServer.cs
+++ b/Projects/MakeMeLaugh_Server/Assets/Scripts/TransportServer.cs
@@ -11,7 +11,7 @@ public class TransportServer : MonoBehaviour
 
     NetworkDriver m_Driver;
     NativeList<NetworkConnection> m_Connections;
-    public event EventHandler OnPlayerMessageReceived;
+    public event EventHandler<PlayerMessageEventArgs> OnPlayerMessageReceived;
 
     private Dictionary<string, NetworkConnection> playerToNetworkConnection = new Dictionary<string, NetworkConnection>();
 
@@ -74,12 +74,6 @@ public class TransportServer : MonoBehaviour
             m_Connections.Add(c);
             Debug.Log("Accepted a connection.");
         }
-
-        // to be deleted.. just tesitng server-to-client comms
-        if (Input.GetKeyDown(KeyCode.T)) {
-            BroadcastMessage(MessageType.PLAYER_ANSWER_SUBMISSION, "broadcast there");
-        }
-        
         for (int i = 0; i < m_Connections.Length; i++)
         {
             DataStreamReader stream;
@@ -96,16 +90,17 @@ public class TransportServer : MonoBehaviour
                     if (playerMessage.MessageType == MessageType.NEW_CLIENT_CONNECTION)
                     {
                         registerNewPlayer(playerMessage, m_Connections[i]);
-                        SendMessageToPlayer(playerMessage.PlayerUuid, MessageType.PLAYER_ANSWER_SUBMISSION, "hello from server");
+                        
+                        // example of how to send data to a specific player
+                        // SendMessageToPlayer(playerMessage.PlayerUuid, MessageType.PLAYER_ANSWER_SUBMISSION, "hello from server");
                     }
                     else
                     {
                         // some kind of game events
-                        // TODO: pass the even details
-                        OnPlayerMessageReceived?.Invoke(this, EventArgs.Empty);
+                        OnPlayerMessageReceived?.Invoke(this, new PlayerMessageEventArgs(playerMessage));
                     }
                     
-                    SendMessageToPlayer(playerMessage.PlayerUuid, MessageType.NEW_CLIENT_CONNECTION, "connection confirmed");
+                    // SendMessageToPlayer(playerMessage.PlayerUuid, MessageType.NEW_CLIENT_CONNECTION, "connection confirmed");
                     rawMessage.Dispose();
                 }
                 else if (cmd == NetworkEvent.Type.Disconnect)


### PR DESCRIPTION
Add a prettier event handler;

You can add a listener to some player message; here is an example:
```C#
using System.Collections;
using System.Collections.Generic;
using UnityEngine;

public class SampleEventListener : MonoBehaviour
{
    // Start is called before the first frame update
    void Start()
    {
        TransportServer.Instance.OnPlayerMessageReceived += TransportServer_OnPlayerMessageReceived;
    }
    
    private void TransportServer_OnPlayerMessageReceived (object sender, PlayerMessageEventArgs eventArgs) {
        Debug.Log("(ATTENTION!) Received the following from the client: " + eventArgs.EventPlayerMessage.MessageContent);
    }
}

```

And if you want to test client communication, the `ClientTester.cs` can be modified to simulate stuff:
```C#
        // Somewhere in Update()....
        // to be deleted.. just tesitng server-to-client comms
        if (Input.GetKeyDown(KeyCode.T)) {
            PlayerMessage message = new PlayerMessage(ClientUuid, MessageType.PLAYER_ANSWER_SUBMISSION, "HERE IS MY ANSWER");
            m_Driver.BeginSend(m_Connection, out var writer);
            NativeArray<byte> messageBytes = PlayerMessage.GetBytes(message);
                
            writer.WriteBytes(messageBytes);
                
            m_Driver.EndSend(writer);
            messageBytes.Dispose();
        }
```


